### PR TITLE
Add tmp directory (.gitignore its content only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 db/*.sqlite3
 log
 node_modules
-tmp
+tmp/*
+!tmp/.keep
 public/assets
 public/system
 public/uploads


### PR DESCRIPTION
Fix the following problem:

```
root@computer:sharedlists# docker-compose run --rm app rake db:setup
Starting sharedlists_mysql_1 ... done
development already exists
=> Generating INITIAL SECRET_TOKEN in /srv/app/tmp/secret_token
rake aborted!
Errno::ENOENT: No such file or directory @ rb_sysopen - /srv/app/tmp/secret_token
```