### PR TITLE
Allow FTP sync for non-BNN formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,28 @@ in its `config/app_config.yml`. Don't forget to grant the Foodsoft database user
 Articles in the database can be updated regularly. There are currently two options to
 do this automatically.
 
-### BNN
+### FTP
 
-In Germany, there is an association for organic food, [BNN](http://n-bnn.de/), that has
-a standard for distributing data over FTP. A [cron](https://en.wikipedia.org/wiki/Cron)job
-needs to setup using [`whenever`](https://github.com/javan/whenever).
+Some suppliers distribute article lists via FTP. You can use the rake task
+called `sync_ftp` in order to download and parse those article lists. First, you
+need to enable FTP synchronization for a certain supplier by activating the
+checkbox _Synchronize FTP files_. Fill out all corresponding form fields. In
+particular, make sure to adjust the *file filter (regular expression)* such that
+it matches the files of interest; non-matching files are ignored. The two
+supported file formats and sensible choices for a corresponding *file filter*
+are shown in the following table.
 
-To enable this for a certain supplier, tick the checkbox _Synchronize BNN files_ and enter
-the FTP credentials.
+| file format                 | example file filter           |
+|-----------------------------|-------------------------------|
+| [BNN3][bnn3-format]         | `\A(?:[.]/)?PL.{0,6}[.]BNN\z` |
+| [foodsoft][foodsoft-format] | `\A(?:[.]/)?.+[.]csv\z`       |
+
+[bnn3-format]: https://github.com/foodcoops/foodsoft/wiki/File-formats-for-article-lists#user-content-format-bnn3
+[foodsoft-format]: https://github.com/foodcoops/foodsoft/wiki/File-formats-for-article-lists#user-content-format-foodsoft
+
+Once you have the `sync_ftp` task working, you may wish to setup a
+[cron](https://en.wikipedia.org/wiki/Cron)job using
+[`whenever`](https://github.com/javan/whenever).
 
 ### Email
 

--- a/app/controllers/suppliers_controller.rb
+++ b/app/controllers/suppliers_controller.rb
@@ -59,10 +59,10 @@ class SuppliersController < ApplicationController
 
     respond_to do |format|
       # @todo fix by generating proper hidden input in html
-      attrs[:bnn_sync] ||= false
+      attrs[:ftp_sync] ||= false
       attrs[:mail_sync] ||= false
       # don't set password to blank on saving
-      attrs = attrs.reject {|k,v| k == 'bnn_password' } if attrs[:bnn_password].blank?
+      attrs = attrs.reject {|k,v| k == 'ftp_password' } if attrs[:ftp_password].blank?
 
       if @supplier.update_attributes(attrs)
         flash[:notice] = 'Supplier was successfully updated.'

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -6,14 +6,12 @@ class Supplier < ActiveRecord::Base
   # save lists in an array in database
   serialize :lists
 
-  # @rails4: enum ftp_type: {bnn: 0, foodsoft: 1}
-  FTP_TYPES = {bnn: 0, foodsoft: 1}
-
+  FTP_TYPES = ['bnn', 'foodsoft'].freeze
   EMAIL_RE = /^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$/i.freeze
 
   validates :name, :address, :phone, presence: true
   validates :ftp_host, :ftp_user, :ftp_password, :ftp_sync, presence: true, if: :ftp_sync?
-  validates :ftp_type, presence: true, inclusion: {in: FTP_TYPES.values}, if: :ftp_sync?
+  validates :ftp_type, presence: true, inclusion: { in: FTP_TYPES }, if: :ftp_sync?
   validates :mail_from, presence: true, format: { with: EMAIL_RE }, if: :mail_sync?
   validates :mail_type, inclusion: { in: ArticleImport.file_formats.keys }, presence: true, if: :mail_sync?
 
@@ -29,10 +27,6 @@ class Supplier < ActiveRecord::Base
 
   def mail_path
     Rails.root.join("supplier_assets", "mail_files", id.to_s)
-  end
-
-  def ftp_type_string
-    FTP_TYPES.key(ftp_type).to_s
   end
 
   # mail hash checked on receiving articles update mail
@@ -59,7 +53,7 @@ class Supplier < ActiveRecord::Base
       new_files.each do |file|
         logger.debug "parse #{file}..."
         outlisted_counter, new_counter, updated_counter, invalid_articles =
-            update_articles_from_file(File.join(ftp_path, file), type: ftp_type_string)
+            update_articles_from_file(File.join(ftp_path, file), type: ftp_type)
         logger.info "#{file} successfully parsed: #{new_counter} new, #{updated_counter} updated, #{outlisted_counter} outlisted, #{invalid_articles.size} invalid"
       end
 

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -6,24 +6,33 @@ class Supplier < ActiveRecord::Base
   # save lists in an array in database
   serialize :lists
 
+  # @rails4: enum ftp_type: {bnn: 0, foodsoft: 1}
+  FTP_TYPES = {bnn: 0, foodsoft: 1}
+
   EMAIL_RE = /^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$/i.freeze
 
   validates :name, :address, :phone, presence: true
-  validates :bnn_host, :bnn_user, :bnn_password, :bnn_sync, presence: true, if: :bnn_sync?
+  validates :ftp_host, :ftp_user, :ftp_password, :ftp_sync, presence: true, if: :ftp_sync?
+  validates :ftp_type, presence: true, inclusion: {in: FTP_TYPES.values}, if: :ftp_sync?
   validates :mail_from, presence: true, format: { with: EMAIL_RE }, if: :mail_sync?
   validates :mail_type, inclusion: { in: ArticleImport.file_formats.keys }, presence: true, if: :mail_sync?
 
-  scope :bnn_sync, ->{ where(bnn_sync: true) }
+  scope :ftp_sync, ->{ where(ftp_sync: true) }
   scope :mail_sync, ->{ where(mail_sync: true) }
 
   before_create :create_salt
 
-  def bnn_path
+  def ftp_path
+    # path should read "ftp_files", but has "bnn_files" for historical reasons
     Rails.root.join("supplier_assets", "bnn_files", id.to_s)
   end
 
   def mail_path
     Rails.root.join("supplier_assets", "mail_files", id.to_s)
+  end
+
+  def ftp_type_string
+    FTP_TYPES.key(ftp_type).to_s
   end
 
   # mail hash checked on receiving articles update mail
@@ -41,16 +50,16 @@ class Supplier < ActiveRecord::Base
     "#{ENV["MAILER_PREFIX"]}#{id}.#{articles_mail_hash}@#{ENV["MAILER_DOMAIN"]}"
   end
 
-  def sync_bnn_files
+  def sync_ftp_files
     new_files = FtpSync::sync(self)
 
     unless new_files.empty?
-      logger.info "New bnn files for #{name}: #{new_files.inspect}"
+      logger.info "New FTP-synced files for #{name}: #{new_files.inspect}"
 
       new_files.each do |file|
         logger.debug "parse #{file}..."
         outlisted_counter, new_counter, updated_counter, invalid_articles =
-            update_articles_from_file(File.join(bnn_path, file), type: 'bnn')
+            update_articles_from_file(File.join(ftp_path, file), type: ftp_type_string)
         logger.info "#{file} successfully parsed: #{new_counter} new, #{updated_counter} updated, #{outlisted_counter} outlisted, #{invalid_articles.size} invalid"
       end
 
@@ -141,26 +150,3 @@ class Supplier < ActiveRecord::Base
     self.salt = [Array.new(6){rand(256).chr}.join].pack("m").chomp
   end
 end
-
-# == Schema Information
-#
-# Table name: suppliers
-#
-#  id            :integer(4)      not null, primary key
-#  name          :string(255)     not null
-#  address       :string(255)     not null
-#  phone         :string(255)     not null
-#  phone2        :string(255)
-#  fax           :string(255)
-#  email         :string(255)
-#  url           :string(255)
-#  delivery_days :string(255)
-#  note          :string(255)
-#  created_on    :datetime
-#  updated_on    :datetime
-#  lists         :string(255)
-#  bnn_sync      :boolean(1)      default(FALSE)
-#  bnn_host      :string(255)
-#  bnn_user      :string(255)
-#  bnn_password  :string(255)
-#

--- a/app/views/suppliers/_form.haml
+++ b/app/views/suppliers/_form.haml
@@ -12,11 +12,13 @@
   /= f.input :min_order_quantity
   /= f.input :article_info_url
 
-  = f.input :bnn_sync
-  %div#bnn_details{style: ('display: none' unless @supplier.bnn_sync?)}
-    = f.input :bnn_host
-    = f.input :bnn_user
-    = f.input :bnn_password
+  = f.input :ftp_sync
+  %div#ftp_details{style: ('display: none' unless @supplier.ftp_sync?)}
+    = f.input :ftp_host
+    = f.input :ftp_user
+    = f.input :ftp_password
+    = f.input :ftp_type, collection: Supplier::FTP_TYPES, include_blank: false
+    = f.input :ftp_regexp
 
   = f.input :mail_sync
   %div#mail_details{style: ('display: none' unless @supplier.mail_sync?)}
@@ -39,8 +41,8 @@
 
   - content_for :javascript do
     :javascript
-      $(document).on('change', '#supplier_bnn_sync', function() {
-        $('#bnn_details').toggle(this.checked);
+      $(document).on('change', '#supplier_ftp_sync', function() {
+        $('#ftp_details').toggle(this.checked);
       });
       $(document).on('change', '#supplier_mail_sync', function() {
         $('#mail_details').toggle(this.checked);

--- a/app/views/suppliers/_form.haml
+++ b/app/views/suppliers/_form.haml
@@ -18,7 +18,7 @@
     = f.input :ftp_user
     = f.input :ftp_password
     = f.input :ftp_type, collection: Supplier::FTP_TYPES, include_blank: false
-    = f.input :ftp_regexp
+    = f.input :ftp_regexp, hint: t('.ftp_regexp_hint')
 
   = f.input :mail_sync
   %div#mail_details{style: ('display: none' unless @supplier.mail_sync?)}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,3 +50,6 @@ en:
       article: Article
       supplier: Supplier
       user: User
+  suppliers:
+    form:
+      ftp_regexp_hint: "Must fit to file format. Example: \\A(?:[.]/)?PL.{0,6}[.]BNN\\z for bnn, \\A(?:[.]/)?.+[.]csv\\z for foodsoft."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,10 +19,12 @@ en:
         units: Units
       supplier:
         address: Address
-        bnn_host: BNN host
-        bnn_user: BNN user
-        bnn_password: BNN password
-        bnn_sync: Synchronise BNN files
+        ftp_host: FTP host
+        ftp_user: FTP user
+        ftp_password: FTP password
+        ftp_sync: Synchronise files via FTP
+        ftp_type: File format
+        ftp_regexp: File filter (regexp)
         delivery_days: Delivery days
         email: Email
         fax: Fax

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,7 +19,7 @@
 
 # Learn more: http://github.com/javan/whenever
 
-# Get newest articles from suppliers via bnn sync, every day at 11:14, 16:14 and 20:14
+# Get newest articles from suppliers via ftp sync, every day at 11:14, 16:14 and 20:14
 every '14 11,16,20 * * *' do
-  rake 'sync_bnn_files'
+  rake 'sync_ftp_files'
 end

--- a/db/migrate/20190611173201_generalize_ftp_sync_beyond_bnn.rb
+++ b/db/migrate/20190611173201_generalize_ftp_sync_beyond_bnn.rb
@@ -1,0 +1,11 @@
+class GeneralizeFtpSyncBeyondBnn < ActiveRecord::Migration
+  def change
+    rename_column :suppliers, :bnn_sync, :ftp_sync
+    rename_column :suppliers, :bnn_host, :ftp_host
+    rename_column :suppliers, :bnn_user, :ftp_user
+    rename_column :suppliers, :bnn_password, :ftp_password
+
+    add_column :suppliers, :ftp_type, :integer, default: 0, null: false, after: :ftp_password
+    add_column :suppliers, :ftp_regexp, :string, default: '^(\.\/)?PL', after: :ftp_type
+  end
+end

--- a/db/migrate/20190612080735_revise_ftp_fields_in_suppliers.rb
+++ b/db/migrate/20190612080735_revise_ftp_fields_in_suppliers.rb
@@ -1,0 +1,11 @@
+class ReviseFtpFieldsInSuppliers < ActiveRecord::Migration
+  def up
+    change_column :suppliers, :ftp_type, :string, default: 'bnn', null: true
+    change_column_default :suppliers, :ftp_regexp, '^([.]/)?PL'
+  end
+
+  def down
+    change_column :suppliers, :ftp_type, :integer, default: 0
+    change_column_default :suppliers, :ftp_regexp, '^(\.\/)?PL'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190611173201) do
+ActiveRecord::Schema.define(:version => 20190612080735) do
 
   create_table "articles", :force => true do |t|
     t.string   "name",                                                          :null => false
@@ -36,9 +36,9 @@ ActiveRecord::Schema.define(:version => 20190611173201) do
   add_index "articles", ["number", "supplier_id"], :name => "index_articles_on_number_and_supplier_id", :unique => true
 
   create_table "suppliers", :force => true do |t|
-    t.string   "name",                                      :null => false
-    t.string   "address",                                   :null => false
-    t.string   "phone",                                     :null => false
+    t.string   "name",                                    :null => false
+    t.string   "address",                                 :null => false
+    t.string   "phone",                                   :null => false
     t.string   "phone2"
     t.string   "fax"
     t.string   "email"
@@ -51,13 +51,13 @@ ActiveRecord::Schema.define(:version => 20190611173201) do
     t.string   "ftp_host"
     t.string   "ftp_user"
     t.string   "ftp_password"
-    t.integer  "ftp_type",      :default => 0,              :null => false
-    t.string   "ftp_regexp",    :default => "^(\\.\\/)?PL"
+    t.string   "ftp_type",      :default => "bnn"
+    t.string   "ftp_regexp",    :default => "^([.]/)?PL"
     t.boolean  "mail_sync"
     t.string   "mail_from"
     t.string   "mail_subject"
     t.string   "mail_type"
-    t.string   "salt",                                      :null => false
+    t.string   "salt",                                    :null => false
   end
 
   add_index "suppliers", ["name"], :name => "index_suppliers_on_name", :unique => true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20170901200146) do
+ActiveRecord::Schema.define(:version => 20190611173201) do
 
   create_table "articles", :force => true do |t|
     t.string   "name",                                                          :null => false
@@ -36,9 +36,9 @@ ActiveRecord::Schema.define(:version => 20170901200146) do
   add_index "articles", ["number", "supplier_id"], :name => "index_articles_on_number_and_supplier_id", :unique => true
 
   create_table "suppliers", :force => true do |t|
-    t.string   "name",                             :null => false
-    t.string   "address",                          :null => false
-    t.string   "phone",                            :null => false
+    t.string   "name",                                      :null => false
+    t.string   "address",                                   :null => false
+    t.string   "phone",                                     :null => false
     t.string   "phone2"
     t.string   "fax"
     t.string   "email"
@@ -47,15 +47,17 @@ ActiveRecord::Schema.define(:version => 20170901200146) do
     t.string   "note"
     t.datetime "created_on"
     t.datetime "updated_on"
-    t.boolean  "bnn_sync",      :default => false
-    t.string   "bnn_host"
-    t.string   "bnn_user"
-    t.string   "bnn_password"
+    t.boolean  "ftp_sync",      :default => false
+    t.string   "ftp_host"
+    t.string   "ftp_user"
+    t.string   "ftp_password"
+    t.integer  "ftp_type",      :default => 0,              :null => false
+    t.string   "ftp_regexp",    :default => "^(\\.\\/)?PL"
     t.boolean  "mail_sync"
     t.string   "mail_from"
     t.string   "mail_subject"
     t.string   "mail_type"
-    t.string   "salt",                             :null => false
+    t.string   "salt",                                      :null => false
   end
 
   add_index "suppliers", ["name"], :name => "index_suppliers_on_name", :unique => true

--- a/lib/ftp_sync.rb
+++ b/lib/ftp_sync.rb
@@ -2,24 +2,23 @@ require 'net/ftp'
 require 'fileutils'
 
 module FtpSync
-  
+
   # compares remote with local filelist
   # if local file not exists or older than remote file, download remote file
   # return array with new files
   def self.sync(supplier)
     new_files = Array.new
-    
-    # change local dir to save bnn-files correctly
-    FileUtils.mkdir_p(supplier.bnn_path) unless File.exists?(supplier.bnn_path)
-    Dir.chdir(supplier.bnn_path)
-    
+
+    # change local dir to save files correctly
+    FileUtils.mkdir_p(supplier.ftp_path) unless File.exists?(supplier.ftp_path)
+    Dir.chdir(supplier.ftp_path)
+
     # connect to ftp-server
-    ftp = Net::FTP.new(supplier.bnn_host, supplier.bnn_user, supplier.bnn_password)
-    
+    ftp = Net::FTP.new(supplier.ftp_host, supplier.ftp_user, supplier.ftp_password)
+
     # loop over the remote filelist
     ftp.nlst.each do |filename|
-      # File is an bnn article list? All BNN Files have filenames beginning with PL
-      if filename.match(/^(\.\/)?PL/)
+      if filename.match(Regexp.new(supplier.ftp_regexp))
         # local file not exist or remote file newer ?
         if (File.exist?(filename) and File.new(filename).mtime < ftp.mtime(filename)) or !File.exist?(filename)
           # download
@@ -33,5 +32,5 @@ module FtpSync
     ftp.close
     return new_files
   end
-  
+
 end

--- a/lib/tasks/bnn_sync.rake
+++ b/lib/tasks/bnn_sync.rake
@@ -1,7 +1,2 @@
-desc "Sync bnn files with remote ftp connection. Update articles."
-task :sync_bnn_files => :environment do
-  Supplier.bnn_sync.all.each do |supplier|
-    puts "Sync bnn files for #{supplier.name}..."
-    supplier.sync_bnn_files
-  end
-end
+desc "Sync files via FTP. Update articles. (deprecated legacy task name)"
+task :sync_bnn_files => :sync_ftp_files

--- a/lib/tasks/ftp_sync.rake
+++ b/lib/tasks/ftp_sync.rake
@@ -1,0 +1,7 @@
+desc "Sync files via FTP. Update articles."
+task :sync_ftp_files => :environment do
+  Supplier.ftp_sync.all.each do |supplier|
+    puts "FTP-sync files for #{supplier.name}..."
+    supplier.sync_ftp_files
+  end
+end


### PR DESCRIPTION
See http://foodsoft.51229.x6.nabble.com/Use-sharedlists-with-non-BNN-format-tt2309.html

TODO:
- [x] Update `README.md`
- [x] Rebase (and combine the two database migrations) if that is a good thing