### PR TITLE
pin haml version to ~> 4 (for rails 3 support)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem 'rails', '~> 3.2.22'
-gem "haml"
+gem 'haml', '~> 4' # compatible with rails 3
 gem "mysql2", '~> 0.3.1' # compatible with rails 3
 gem "bcrypt-ruby", :require => "bcrypt"
 gem 'will_paginate', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
       multi_json (~> 1.0)
     arel (3.0.3)
     base32 (0.3.2)
-    bcrypt (3.1.12)
+    bcrypt (3.1.13)
     bcrypt-ruby (3.1.5)
       bcrypt (>= 3.1.3)
     builder (3.0.4)
@@ -45,10 +45,9 @@ GEM
     concurrent-ruby (1.1.5)
     erubis (2.7.0)
     execjs (2.7.0)
-    ffi (1.10.0)
+    ffi (1.11.1)
     gserver (0.0.1)
-    haml (5.0.4)
-      temple (>= 0.8.0)
+    haml (4.0.7)
       tilt
     hike (1.2.3)
     i18n (0.9.5)
@@ -65,12 +64,12 @@ GEM
     midi-smtp-server (2.3.1)
     mime-types (1.25.1)
     mini_portile2 (2.4.0)
-    multi_json (1.13.1)
+    multi_json (1.14.1)
     mysql2 (0.3.21)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     polyglot (0.3.5)
-    power_assert (1.1.3)
+    power_assert (1.1.5)
     rack (1.4.7)
     rack-cache (1.9.0)
       rack (>= 0.4)
@@ -93,7 +92,7 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
-    rake (12.3.2)
+    rake (13.0.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -108,8 +107,8 @@ GEM
       roo (>= 2.0.0, < 3)
       spreadsheet (> 0.9.0)
     ruby-ole (1.2.12.2)
-    rubyzip (1.2.2)
-    sass (3.7.3)
+    rubyzip (1.3.0)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -121,15 +120,14 @@ GEM
     simple_form (2.1.3)
       actionpack (~> 3.0)
       activemodel (~> 3.0)
-    spreadsheet (1.2.3)
+    spreadsheet (1.2.5)
       ruby-ole (>= 1.0)
     sprockets (2.2.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    temple (0.8.1)
-    test-unit (3.3.0)
+    test-unit (3.3.4)
       power_assert
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
@@ -140,11 +138,11 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.55)
-    uglifier (4.1.20)
+    uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    whenever (0.10.0)
+    whenever (0.11.0)
       chronic (>= 0.6.3)
-    will_paginate (3.1.6)
+    will_paginate (3.2.1)
 
 PLATFORMS
   ruby
@@ -154,7 +152,7 @@ DEPENDENCIES
   bcrypt-ruby
   coffee-rails
   gserver
-  haml
+  haml (~> 4)
   jquery-rails
   midi-smtp-server
   mysql2 (~> 0.3.1)


### PR DESCRIPTION
The `haml` gem [dropped rails-3 support](https://github.com/haml/haml/blob/master/CHANGELOG.md#user-content-500) starting from haml 5.