### PR TITLE
feat: add foodcoop field to supplier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby '3.2.2'
 gem 'rails', '~> 7.1'
 gem 'rails-i18n', '~> 7.0'
 gem 'importmap-rails', '~> 1.2'
+gem 'sassc-rails'
 gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'puma', '~> 6.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,6 +251,14 @@ GEM
     ruby-ole (1.2.12.2)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -261,6 +269,13 @@ GEM
     spreadsheet (1.3.0)
       ruby-ole
     spring (4.1.3)
+    sprockets (4.2.1)
+      concurrent-ruby (~> 1.0)
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      sprockets (>= 3.0.0)
     sqlite3 (1.6.9)
       mini_portile2 (~> 2.8.0)
     stimulus-rails (1.2.1)
@@ -328,6 +343,7 @@ DEPENDENCIES
   rails-i18n (~> 7.0)
   roo
   roo-xls
+  sassc-rails
   selenium-webdriver
   simple_form
   spring

--- a/app/controllers/suppliers_controller.rb
+++ b/app/controllers/suppliers_controller.rb
@@ -111,7 +111,8 @@ class SuppliersController < ApplicationController
         :mail_sync,
         :mail_type,
         :mail_from,
-        :mail_subject
+        :mail_subject,
+        :foodcoop
       )
   end
 end

--- a/app/views/suppliers/_form.haml
+++ b/app/views/suppliers/_form.haml
@@ -11,6 +11,10 @@
   = f.input :note, as: :text, input_html: {rows: 5, cols: 60}
   /= f.input :min_order_quantity
   /= f.input :article_info_url
+  %div
+    = f.input :foodcoop
+    %p
+      #{t('.foodcoop_help_text')}
 
   = f.input :ftp_sync
   %div#ftp_details{style: ('display: none' unless @supplier.ftp_sync?)}

--- a/app/views/suppliers/index.haml
+++ b/app/views/suppliers/index.haml
@@ -8,6 +8,7 @@
     %th= t('.address')
     %th= t('.phone')
     %th= t('.delivery_days')
+    %th= t('.foodcoop')
     %th= t('.note')
     %th= t('.last update')
     %th= t('.article')
@@ -17,6 +18,7 @@
       %td= supplier.address
       %td= supplier.phone
       %td= supplier.delivery_days
+      %td= supplier.foodcoop
       %td= supplier.note
       %td= I18n.l supplier.articles_updated_at rescue nil
       %td= link_to supplier.articles.size.to_s + ' ' + t('.articles'), supplier_articles_url(supplier)

--- a/app/views/suppliers/show.haml
+++ b/app/views/suppliers/show.haml
@@ -28,6 +28,10 @@
   %br/
   %strong= @supplier.delivery_days
 %p
+  #{t('.foodcoop')}:
+  %br/
+  %strong= @supplier.foodcoop
+%p
   #{t('.note')}:
   %br/
   %strong= @supplier.note

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -38,6 +38,7 @@ de:
         phone: Telefon
         phone2: Telefon 2
         url: Webseite
+        foodcoop: Foodcoop
       user:
         email: Email
         first_name: Vorname
@@ -73,6 +74,7 @@ de:
   suppliers:
     form:
       ftp_regexp_hint: "Muss den Dateiformat entsprechend. Beispiel: \\A(?:[.]/)?PL.{0,6}[.]BNN\\z für bnn, \\A(?:[.]/)?.+[.]csv\\z für foodsoft."
+      foodcoop_help_text: "Optional: Beschränkung auf eine Foodcoop, muss ein Foodcoop config name aus Foodsoft sein"
     index:
       add_supplier: Lieferant hinzufügen
       articles: Artikel

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
         phone: Phone
         phone2: Phone 2
         url: Website
+        foodcoop: Foodcoop
       user:
         email: Email
         first_name: First name
@@ -73,6 +74,7 @@ en:
   suppliers:
     form:
       ftp_regexp_hint: "Must fit to file format. Example: \\A(?:[.]/)?PL.{0,6}[.]BNN\\z for bnn, \\A(?:[.]/)?.+[.]csv\\z for foodsoft."
+      foodcoop_help_text: "Optional: restrict to a foodcoop, needs to be a foodcoop config name in foodsoft"
     index:
       add_supplier: Add supplier
       articles: Articles

--- a/db/migrate/20231214145104_add_foodcoop_to_suppliers.rb
+++ b/db/migrate/20231214145104_add_foodcoop_to_suppliers.rb
@@ -1,0 +1,6 @@
+class AddFoodcoopToSuppliers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :suppliers, :foodcoop, :string
+  end
+end
+  

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_01_150110) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_14_145104) do
   create_table "articles", force: :cascade do |t|
     t.string "name", null: false
     t.integer "supplier_id", null: false
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_01_150110) do
     t.string "mail_subject"
     t.string "mail_type"
     t.string "salt", null: false
+    t.string "foodcoop"
     t.index ["name"], name: "index_suppliers_on_name", unique: true
   end
 


### PR DESCRIPTION
Can be used in Foodsoft to filter for foodcoops in multisite setups